### PR TITLE
update telemetry dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule TelemetryDecorator.MixProject do
       {:excoveralls, "~> 0.14.1", only: :test, runtime: false},
       {:mix_test_watch, "~> 1.0.2", only: :dev, runtime: false},
       {:pretty, "~> 1.0.4"},
-      {:telemetry, "~> 0.4.2"}
+      {:telemetry, "~> 1.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -22,6 +22,6 @@
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "pretty": {:hex, :pretty, "1.0.8", "10bb0da3942872aa7a70a3abe559bfa51809d7dfc538b404ff8af94e93fb7600", [:mix], [], "hexpm", "5c523254c415e98b0bf737bc859a80f81c93ad2ead280193e5e7d3af1fd42c60"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
-  "telemetry": {:hex, :telemetry, "0.4.3", "a06428a514bdbc63293cd9a6263aad00ddeb66f608163bdec7c8995784080818", [:rebar3], [], "hexpm", "eb72b8365ffda5bed68a620d1da88525e326cb82a75ee61354fc24b844768041"},
+  "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }


### PR DESCRIPTION
The telemetry team has made [version 1.0 release](https://github.com/beam-telemetry/telemetry/blob/main/CHANGELOG.md#100) without any change. Version 1 release marks the stability of the API.